### PR TITLE
DDPB-2785: Enable test environment on training

### DIFF
--- a/environment/terraform.tfvars.json
+++ b/environment/terraform.tfvars.json
@@ -134,7 +134,7 @@
   "test_enabled":{
     "production02": false,
     "preprod": false,
-    "training": false,
+    "training": true,
     "develop": true,
     "master": true,
     "feature-1": true,


### PR DESCRIPTION
Because training is part of the development AWS account, it does not have full access to sending emails. This means that any emails sent from the training account disappear and cannot be acted upon (e.g. to activate trianing accounts).

This change will make the training environment use the "test" environment config, which will enable email catching. This allows emails sent from the training environment to be intercepted and handled.